### PR TITLE
set default logging in the microengine to debug, to help with learnin…

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker/Dockerfile
+++ b/{{ cookiecutter.project_slug }}/docker/Dockerfile
@@ -1,7 +1,10 @@
 FROM polyswarm/polyswarm-client
 
-# remove polyswarm client data that should already be installed
-RUN rm -Rf /usr/src/app
+# remove polyswarm client source, since it was already installed, but keep testing keyfiles
+RUN mv /usr/src/app /usr/src/psc \
+ && mkdir -p /usr/src/app/docker \
+ && cp -a /usr/src/psc/docker/*_keyfile /usr/src/app/docker/ \
+ && rm -rf /usr/src/psc
 
 WORKDIR /usr/src/app
 

--- a/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.package_slug }}/__init__.py
+++ b/{{ cookiecutter.project_slug }}/src/{{ cookiecutter.package_slug }}/__init__.py
@@ -6,6 +6,7 @@ import os
 
 from polyswarmclient.abstractmicroengine import AbstractMicroengine
 from polyswarmclient.abstractscanner import AbstractScanner, ScanResult
+from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Init logger
 
@@ -62,6 +63,7 @@ class Microengine(AbstractMicroengine):
             scanner ('Scanner'): Scanner we are using to process artifacts
             chains (set[str]): Chain we are operating on
         """
+        init_logging('json', logging.DEBUG)
         logger.info("Loading {{ cookiecutter.engine_name }} scanner...")
         scanner = Scanner()
         {% if cookiecutter.has_backend == "true" %}


### PR DESCRIPTION
…g/testing. clean up the polyswarm-client source, but keep the keyfiles, so they are available for integration tests.